### PR TITLE
This replaces python's `time.clock()` with `time.perf_counter()`

### DIFF
--- a/PyCidX/commandExecution.py
+++ b/PyCidX/commandExecution.py
@@ -19,7 +19,7 @@ def runCommand( cmdIn, paramsIn, logFileName=None, workDir=None, onlyPrintComman
     print('Executing:\n -> %s %s' % ( cmdIn, paramsIn ) )
     cmd = shlex.split ( cmdIn + ' ' + paramsIn, posix=False ) 
 
-    tic = time.clock()
+    tic = time.perf_counter()
     ret = 0
     
     if not onlyPrintCommand :
@@ -37,7 +37,7 @@ def runCommand( cmdIn, paramsIn, logFileName=None, workDir=None, onlyPrintComman
     if workDir != None :
         os.chdir( curDir )
     
-    toc = time.clock()
+    toc = time.perf_counter()
     
     print('Done. This took %.2fs' %( toc-tic ) )
     return ret


### PR DESCRIPTION
`time.perf_counter()` was introduced in Python 3.3 to replace `time.clock()`
as it displays platform-specific behaviour. `time.clock()` was removed in
Python 3.8 (see here: https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals).

`time.clock()` was used in `commandExecution.py` to measure the time taken by niftyreg.
This raises an exception in Python 3.8, making the library think the XCAT DVFs are corrupt,
while they are fine.