### PR TITLE
Mask generation region now set to accommodate simulations without partial volume effects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Docu/build
 .idea
 __pycache__
+.venv

--- a/PyCidX/convertXCATDVFTextFile.py
+++ b/PyCidX/convertXCATDVFTextFile.py
@@ -348,7 +348,7 @@ def convertXCATDVFTextFileToNiftiImage( inputXCATDVFFileName,
     if generateDVFNiiFile:
         # Calculate a mask image from the structural one and find the region outside which needs to be replaced with the closest inside values
         maskData = np.ones_like( structuralNii.get_fdata() )
-        maskData[ np.where(structuralNii.get_fdata() > np.min(structuralNii.get_fdata()[structuralNii.get_fdata()!=0])) ] = 0
+        maskData[ np.where(structuralNii.get_fdata() >= np.min(structuralNii.get_fdata()[structuralNii.get_fdata()!=0])) ] = 0
         
         maskData = binary_dilation(maskData).astype(maskData.dtype)
         indices = distance_transform_edt( maskData, voxelSize, return_distances=False, return_indices=True )


### PR DESCRIPTION
Including the minimum value for thresholding simulated images without partial volume effect should be sufficient to define the extrapolation mask correctly. For images with partial volume effect this change should be without noticeable effect. 